### PR TITLE
Force tcpdump to no longer buffer packets and flush to disk

### DIFF
--- a/cap_until.rb
+++ b/cap_until.rb
@@ -35,7 +35,7 @@ end
 scan_delay = 1
 
 @tcpdump = Process.spawn(
-  'tcpdump', '-Z', 'root',  '-z', 'gzip', '-i', options[:interface], '-w', "#{options[:prefix]}%m%d%H%M.pcap", '-G', "#{options[:rotate]}", options[:filter]
+  'tcpdump', '-U', '-Z', 'root',  '-z', 'gzip', '-i', options[:interface], '-w', "#{options[:prefix]}%m%d%H%M.pcap", '-G', "#{options[:rotate]}", options[:filter]
 )
 Process.detach @tcpdump
 


### PR DESCRIPTION
To ensure packet data is available in the output file when
the process is killed, we should flush to disk far more often
than the default.  This patch adds the -U flag to tcpdump, which
will force a flush to disk on each packet rather than waiting for
the 4k buffer to fill.