### PR TITLE
Switch from SIGKILL to SIGTERM

### DIFF
--- a/cap_until.rb
+++ b/cap_until.rb
@@ -41,7 +41,7 @@ Process.detach @tcpdump
 
 def quit_all retval=0, exception=nil
   begin
-    Process.kill "SIGKILL", @tcpdump
+    Process.kill "SIGTERM", @tcpdump
     log "Exiting."
   rescue Errno::ESRCH
   end


### PR DESCRIPTION
This patch switches the tcpdump kill to a SIGTERM to allow the
process to flush any related data to disk and clean up after
itself.